### PR TITLE
Preventing Nginx Auth with PHP errors

### DIFF
--- a/config.php
+++ b/config.php
@@ -58,4 +58,9 @@ define('SESSION_NAME','2fatkn');
 // the originating URL
 // Otherwise, redirect to the URL specified here
 define('AUTH_SUCCEED_REDIRECT_URL','https://www.example.com/');
+
+// If you are using TwoFactorAuth with nginx, and are experiencing common issues
+// like infinite redirects or failed authentications, you can log authentication
+// activity to the file /nginx/debug.log for your review.
+define('TFA_NGINX_DEBUG', false);
 ?>

--- a/lib/TFAErrorHandler.php
+++ b/lib/TFAErrorHandler.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * TwoFactorAuth main configuration file
+ *
+ * @author Arno0x0x - https://twitter.com/Arno0x0x
+ * @license GPLv3 - licence available here: http://www.gnu.org/copyleft/gpl.html
+ * @link https://github.com/Arno0x/
+ */
+
+//========================================================================
+// Suppress fatal errors in the config file
+//========================================================================
+
+class TFAErrorHandler
+{
+  public static function handle_fatal_error() {
+    $error = error_get_last();
+
+    if ($error) {
+      switch ($error['type']) {
+        case E_ERROR:
+        case E_PARSE:
+        case E_CORE_ERROR:
+        case E_COMPILE_ERROR:
+        case E_USER_ERROR:
+        case E_RECOVERABLE_ERROR:
+          // don't authenticate!!
+          http_response_code(401);
+          break;
+      }
+    }
+  }
+}

--- a/lib/TFAErrorHandler.php
+++ b/lib/TFAErrorHandler.php
@@ -13,21 +13,32 @@
 
 class TFAErrorHandler
 {
-  public static function handle_fatal_error() {
-    $error = error_get_last();
+	public static function handle_fatal_error() {
+		$error = @error_get_last();
 
-    if ($error) {
-      switch ($error['type']) {
-        case E_ERROR:
-        case E_PARSE:
-        case E_CORE_ERROR:
-        case E_COMPILE_ERROR:
-        case E_USER_ERROR:
-        case E_RECOVERABLE_ERROR:
-          // don't authenticate!!
-          http_response_code(401);
-          break;
-      }
-    }
-  }
+		if ($error) {
+			switch ($error['type']) {
+				case E_ERROR:
+				case E_PARSE:
+				case E_CORE_ERROR:
+				case E_COMPILE_ERROR:
+				case E_USER_ERROR:
+				case E_RECOVERABLE_ERROR:
+				{
+					// don't authenticate!!
+					http_response_code(401);
+					break;
+				}
+			}
+		}
+	}
+
+	public static function handle_exception($e) {
+		// don't authenticate!!
+		http_response_code(401);
+	}
+
+	public static function handle_php_error($error_type, $error_string, $file, $line) {
+
+	}
 }

--- a/nginx/auth.php
+++ b/nginx/auth.php
@@ -30,12 +30,19 @@ if (file_exists('../config.php')) {
 
 // * ========================= DEBUG BLOCK ========================== 
 
-if (defined('TFA_DEBUG_ON') AND TFA_DEBUG_ON)
+if (defined('TFA_NGINX_DEBUG') AND TFA_NGINX_DEBUG)
 {
 	$dir = dirname(__FILE__);
 	$debugFileName = $dir.DIRECTORY_SEPARATOR."debug.log";
+	$canLog = false;
 
-	if (is_writable($dir) AND (!file_exists($logName) OR is_writable($logName))) {
+	if (!file_exists($logName)) {
+		$canLog = is_writable($dir);
+	} else if (is_writable($logName))) {
+		$canLog = true;
+	}
+
+	if ($canLog) {
 		$debugHandle = fopen ($debugFileName ,"a");
 
 		foreach ($_SERVER as $key => $value) {

--- a/nginx/auth.php
+++ b/nginx/auth.php
@@ -41,7 +41,7 @@ if (defined('TFA_NGINX_DEBUG') AND TFA_NGINX_DEBUG)
 
 	if (!file_exists($logName)) {
 		$canLog = is_writable($dir);
-	} else if (is_writable($logName))) {
+	} else if (is_writable($logName)) {
 		$canLog = true;
 	}
 

--- a/nginx/auth.php
+++ b/nginx/auth.php
@@ -74,11 +74,11 @@ session_start();
 //====================================================
 // Check if the authentication has been completed
 if (isset($_SESSION["authenticated"]) && $_SESSION["authenticated"] === true) {
-    http_response_code(200);
+	http_response_code(200);
 }
 else {
-	    // Else return an HTTP 401 status code
-	    session_destroy();
+	// Else return an HTTP 401 status code
+	session_destroy();
 		http_response_code(401);
 	}
 ?>

--- a/nginx/auth.php
+++ b/nginx/auth.php
@@ -14,7 +14,10 @@
 if (file_exists('../config.php')) {
 	// don't authenticate whenever there is a fatal error in the config file
 	require_once("../lib/TFAErrorHandler.php");
+
 	register_shutdown_function(array('TFAErrorHandler', 'handle_fatal_error'));
+	set_exception_handler(array('TFAErrorHandler', 'handle_exception'));
+	set_error_handler(array('TFAErrorHandler', 'handle_php_error'));
 
 	try {
 		require_once("../config.php");

--- a/readme.md
+++ b/readme.md
@@ -124,6 +124,8 @@ The Nginx auth_request module allows authentication of each request against an i
 
 This mechanism is a perfect replacement for the auth_basic authentication and allows for custom made mechanism, written in any language. It also allows a whole website (not per application) authentication mechanism.
 
+WARNING: Whenever you save changes to TwoFactorAuth's config.php, always check for error messages at /twofactorauth/login/login.php to ensure you did not make typos in the file. If PHP cannot parse the file, Nginx will consider all users to be authenticated!
+
 TwoFactorAuth provides such a script: **/twofactorauth/nginx/auth.php**.
 
 You'll have to edit your Nginx configuration file. Assuming the TwoFactorAuth application was deployed in a location named /twofactorauth/ on your webserver, add the following line under the "server" directive:
@@ -144,7 +146,7 @@ You'll have to edit your Nginx configuration file. Assuming the TwoFactorAuth ap
     }
  
     location /twofactorauth/db/ {
-				deny all;
+		deny all;
 	}
 	
     location /twofactorauth/login/ {


### PR DESCRIPTION
These commits resolve unwanted automatic authentication of users in some cases:

Whenever a PHP error occurs, PHP sends a 200 OK response. This patch fixes that by sending the 401 response for all (catch-able) stop errors. Parse errors are not catch-able, but I have added a warning to the readme about that.
This patch also includes a new debug block that should be more resilient to errors and easier to activate without causing errors.
This patch also prevents auto-authentication while config.php is missing, or while the SESSION_NAME constant is broken.

Please test.

P.S. I have other fixes to add, but they are unrelated to undesired 200 responses.
