### PR TITLE
password = username?

### DIFF
--- a/user/user.php
+++ b/user/user.php
@@ -67,7 +67,7 @@ try {
 			// Show the change password form for the selected user
 			case "changePassword":
 			    if (isset($_POST["password"])) {
-			    	if($dbManager->updatePassword($username,$username)) {
+			    	if($dbManager->updatePassword($username,$_POST['password'])) {
 			    	    $message = "[SUCCESS] Password successfully changed for user ".$username;
 			    	}
 			    	else {


### PR DESCRIPTION
When a user changed his/her own password, it did not set it to the new password. Instead, it set the password to the user's username. This eliminated 1 step in the two-step verification for hackers, and successfully prevented the user from being able to ever login again unless they knew about the bug or asked an admin to reset the password again.

This is a simple code-change, but should remedy the problem.
