### PR TITLE
Fixed a file system vulnerability

### DIFF
--- a/login/login.php
+++ b/login/login.php
@@ -73,7 +73,8 @@ else {
 	        // - Ensure Cookies are not available to Javascript
 	        // - Cookies are sent on https only
 	        $domain = ($_SERVER['HTTP_HOST'] !== 'localhost') ? $_SERVER['SERVER_NAME'] : false;
-	        session_set_cookie_params (0, "/", $domain, true, true);
+		$is_secure = (isset($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] === "on");
+	        session_set_cookie_params (0, "/", $domain, $is_secure, true);
 	    
 	        // Create a session
 	        session_start();
@@ -86,7 +87,7 @@ else {
 	        // Checking which URL we should redirect the user to
 	        if (isset($_POST["from"])) {
 	        	$from = urldecode($_POST["from"]);
-	            $redirectTo = ((isset($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] === "on")? "https://" : "http://").$_SERVER["SERVER_NAME"].":".$_SERVER["SERVER_PORT"].$from;
+			$redirectTo = ($is_secure ? "https://" : "http://").$_SERVER["SERVER_NAME"].":".$_SERVER["SERVER_PORT"].$from;
 	        }
 	        else {
 	            $redirectTo = AUTH_SUCCEED_REDIRECT_URL;

--- a/nginx/auth.php
+++ b/nginx/auth.php
@@ -46,7 +46,12 @@ if (defined('TFA_NGINX_DEBUG') AND TFA_NGINX_DEBUG)
 	}
 
 	if ($canLog) {
-		$debugHandle = fopen ($debugFileName ,"a");
+		$mode = "a";
+		if (file_exists($debugFileName) AND filesize($debugFileName) > 104857600)
+		{
+			$mode = "w";
+		}
+		$debugHandle = fopen ($debugFileName, $mode);
 
 		foreach ($_SERVER as $key => $value) {
 			if (is_array($value)) {


### PR DESCRIPTION
I noticed that some logins failed when auth.php did not submit over HTTPS. Some servers don't have it. TFA now works for sites with no SSL cert.

More importantly, I also noticed that while TFA_NGINX_DEBUG was enabled, it was possible for an attacker to fill the disk partition (using up all free space on the server) by flooding auth.php with requests. The debug.log is now limited to 100M in size. If it exceeds this size, it will be started over. There are definitely better ways to handle over-sized logs, such as rotating, but in the interest of closing the security hole, this is the most expedient solution.
